### PR TITLE
Split test-suite into its own system

### DIFF
--- a/hash-set-tests.asd
+++ b/hash-set-tests.asd
@@ -1,12 +1,10 @@
 (in-package #:asdf-user)
 
-(defsystem #:hash-set
+(defsystem #:hash-set-tests
   :serial t
   :description "An implementation of the hash-set data structure."
   :author "Samuel Chase <samebchase@gmail.com>"
   :license "Unlicense"
-  :depends-on (#:alexandria
-               #:optima)
-  :components ((:file "package")
-               (:file "hash-set"))
-
+  :depends-on (#:hash-set
+               #:fiveam)
+  :components ((:file "test")))

--- a/package.lisp
+++ b/package.lisp
@@ -54,8 +54,3 @@
            #:hs-proper-supersetp
 
            #:hs-powerset))
-
-(defpackage #:hash-set-test
-  (:use #:cl
-        #:fiveam
-        #:hash-set))

--- a/test.lisp
+++ b/test.lisp
@@ -1,3 +1,8 @@
+(defpackage #:hash-set-test
+  (:use #:cl
+        #:fiveam
+        #:hash-set))
+
 (in-package :hash-set-test)
 
 (def-suite all-tests)


### PR DESCRIPTION
Oi Thanks for hash-set,

Splitting the tests into its own system so one doesn't have to load the test dependencies when usiing hash-set 
