### PR TITLE
Some fixes and optimizations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ NIL
 ```
 
 
-##### hs-npop : ```hash-set -> *!hash-set!*```
+##### hs-npop : ```hash-set -> elt *!hash-set!*```
 Modifying version of ```hs-pop```.
 Removes an arbitrary element of hash-set and returns both it and hash-set with the
 element removed.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ HASH-SET> (list-to-hs (alexandria:iota 10))
 #<HASH-SET of count: 10 {1008832EF3}>
 ```
 
+##### hs : ```&rest elements -> hash-set```
+Convenience wrapper around ```list-to-hs``` taking ```&rest``` arguments.
+
+```lisp
+HASH-SET> (hs 1 2 3 4 5)
+#<HASH-SET of count: 5 {1005343743}>
+```
+
 ##### hs-to-list : ```hash-set -> list```
 
 Creates a list containing all the elements of the hash-set.
@@ -191,6 +199,47 @@ of the hash-set.
 
 The elements testing false with the predicate are removed from the
 hash-set.
+
+##### hs-first : ```hash-set -> elt```
+Returns an arbitrary element of hash-set.  This would be the element returned by ```hs-pop```
+or ```hs-npop```
+
+##### hs-pop : ```hash-set -> elt hash-set```
+
+Removes an arbitrary element of hash-set and returns both it and a copy of hash-set
+with the element removed.
+Returns nil on an empty set.
+
+```lisp
+HASH-SET> (hs-pop  (hs 1 2 3 4 5))
+1
+#<HASH-SET of count: 4 {104DE04E43}>
+
+HASH-SET> (hs-pop (hs))
+NIL
+#<HASH-SET of count: 0 {104DE05CD3}>
+```
+
+
+##### hs-npop : ```hash-set -> *!hash-set!*```
+Modifying version of ```hs-pop```.
+Removes an arbitrary element of hash-set and returns both it and hash-set with the
+element removed.
+Returns nil on an empty set.
+
+```lisp
+HASH-SET> (let ((hs (hs 1 2 3 4 5)))
+           (hs-npop hs)
+           (hs-npop hs)
+           (hs-npop hs))
+3
+#<HASH-SET of count: 2 {104DF7DDD3}>
+
+HASH-SET> (hs-npop  (hs))
+NIL
+#<HASH-SET of count: 0 {104DE05CD3}>
+```
+
 
 #### Set operations
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,19 @@ NIL
 #<HASH-SET of count: 0 {104DE05CD3}>
 ```
 
+```hs-pop``` and ```hs-npop``` are useful for iterating over sets when the size can change
+during the loop.
+```lisp
+HASH-SET> (loop :with hs = (list-to-hs (alexandria:iota 10))
+                :while (not (zerop (hs-count hs)))
+                :when (evenp (hs-npop hs))
+                  :do
+                     (dotimes (i 3)
+                       (hs-ninsert hs (random 20)))
+                :do
+                   (format t "hs is now: ~a~%" hs))
+```
+
 
 #### Set operations
 

--- a/README.md
+++ b/README.md
@@ -245,12 +245,13 @@ during the loop.
 ```lisp
 HASH-SET> (loop :with hs = (list-to-hs (alexandria:iota 10))
                 :while (not (zerop (hs-count hs)))
-                :when (evenp (hs-npop hs))
+                :for removed = (hs-npop hs)
+                :when (evenp removed)
                   :do
                      (dotimes (i 3)
                        (hs-ninsert hs (random 20)))
                 :do
-                   (format t "hs is now: ~a~%" hs))
+                   (format t "hs is now: ~a~%" (hs-to-list hs)))
 ```
 
 

--- a/benchmark.lisp
+++ b/benchmark.lisp
@@ -19,6 +19,9 @@
           (hs-ninsert hsa (random a-size)))
         (when (< num b-size)
           (hs-ninsert hsb (random b-size))))
+
+      (format t "====================================================================================================~%")
+      (format t "    Time should be roughly equal.~%")
       (time (hs-intersection hsa hsb))
       (time (hs-intersection hsb hsa)))))
 
@@ -29,6 +32,8 @@
            (inplace-size 500000)
            (hsa (make-hash-set))
            (hsb (make-hash-set inplace-size)))
+      (format t "====================================================================================================~%")
+      (format t "    Second time should be a little faster with no consing, third time slowest with consing.~%")
       (time
        (dotimes (num inplace-size)
          (hs-ninsert hsa (random max-int))))
@@ -57,6 +62,8 @@
         (when (< i small-size)
           (hs-ninsert small-set (random max-int)))
         (hs-insert big-set (random max-int)))
+      (format t "====================================================================================================~%")
+      (format t "    Time should be roughly equal .~%")
       (time (hs-difference big-set small-set))
       (time (hs-difference small-set big-set)))))
 
@@ -65,10 +72,10 @@
   (when *benchmark-enabled*
 
     (let* ((max-int 50000000)
-           (sizes '(100
-                    1000
+           (sizes '(1000
                     10000
-                    100000))
+                    100000
+                    1000000))
            (tables (mapcar #'make-hash-set sizes)))
       (loop :for i :below (car (last sizes))
             :do
@@ -77,6 +84,8 @@
                      :when (< i siz)
                        :do
                           (hs-ninsert tab (random max-int))))
+      (format t "====================================================================================================~%")
+      (format t "    Time should increase linear (by roughly 10x) with no consing.~%")
       (dolist (tab tables)
         (let ((sum 0))
           (time (dohashset (var tab)

--- a/benchmark.lisp
+++ b/benchmark.lisp
@@ -5,7 +5,7 @@
 (in-suite benchmarking)
 
 (use-package :hash-set)
-(defparameter *benchmark-enabled* t)
+(defparameter *benchmark-enabled* nil)
 
 (test intersection-speed
   (when *benchmark-enabled*

--- a/benchmark.lisp
+++ b/benchmark.lisp
@@ -1,0 +1,83 @@
+(in-package :hash-set-test)
+
+(def-suite benchmarking)
+
+(in-suite benchmarking)
+
+(use-package :hash-set)
+(defparameter *benchmark-enabled* t)
+
+(test intersection-speed
+  (when *benchmark-enabled*
+
+    (let ((a-size 0)
+          (b-size 5000000)
+          (hsa (make-hash-set))
+          (hsb (make-hash-set)))
+      (dotimes (num (max  a-size b-size))
+        (when (< num a-size)
+          (hs-ninsert hsa (random a-size)))
+        (when (< num b-size)
+          (hs-ninsert hsb (random b-size))))
+      (time (hs-intersection hsa hsb))
+      (time (hs-intersection hsb hsa)))))
+
+(test insert-speed
+  (when *benchmark-enabled*
+
+    (let* ((max-int 5000000)
+           (inplace-size 500000)
+           (hsa (make-hash-set))
+           (hsb (make-hash-set inplace-size)))
+      (time
+       (dotimes (num inplace-size)
+         (hs-ninsert hsa (random max-int))))
+      (time
+       (dotimes (num inplace-size)
+         (hs-ninsert hsb (random max-int))))
+
+      ;; Fewer inserts because set copy is slow
+      (time
+       (loop :with small-size = 5000
+             :for i :below small-size
+             :for set = (make-hash-set)
+               :then (hs-insert set (random max-int)))))))
+
+
+
+(test difference-speed
+  (when *benchmark-enabled*
+    
+    (let* ((max-int 50000000)
+           (large-size 50000)
+           (small-size 50)
+           (big-set (make-hash-set large-size))
+           (small-set (make-hash-set small-size)))
+      (dotimes (i large-size)
+        (when (< i small-size)
+          (hs-ninsert small-set (random max-int)))
+        (hs-insert big-set (random max-int)))
+      (time (hs-difference big-set small-set))
+      (time (hs-difference small-set big-set)))))
+
+
+(test dohashset-speed
+  (when *benchmark-enabled*
+
+    (let* ((max-int 50000000)
+           (sizes '(100
+                    1000
+                    10000
+                    100000))
+           (tables (mapcar #'make-hash-set sizes)))
+      (loop :for i :below (car (last sizes))
+            :do
+               (loop :for tab :in tables
+                     :for siz :in sizes
+                     :when (< i siz)
+                       :do
+                          (hs-ninsert tab (random max-int))))
+      (dolist (tab tables)
+        (let ((sum 0))
+          (time (dohashset (var tab)
+                  (incf sum var))))))))

--- a/benchmark.lisp
+++ b/benchmark.lisp
@@ -52,7 +52,7 @@
 
 (test difference-speed
   (when *benchmark-enabled*
-    
+
     (let* ((max-int 50000000)
            (large-size 50000)
            (small-size 50)

--- a/benchmark.lisp
+++ b/benchmark.lisp
@@ -33,7 +33,7 @@
            (hsa (make-hash-set))
            (hsb (make-hash-set inplace-size)))
       (format t "====================================================================================================~%")
-      (format t "    Second time should be a little faster with no consing, third time slowest with consing.~%")
+      (format t "    Second time should be a little faster with less consing, third time slowest with more consing.~%")
       (time
        (dotimes (num inplace-size)
          (hs-ninsert hsa (random max-int))))
@@ -85,7 +85,7 @@
                        :do
                           (hs-ninsert tab (random max-int))))
       (format t "====================================================================================================~%")
-      (format t "    Time should increase linear (by roughly 10x) with no consing.~%")
+      (format t "    Time should increase linear (by roughly 10x).~%")
       (dolist (tab tables)
         (let ((sum 0))
           (time (dohashset (var tab)

--- a/hash-set-tests.asd
+++ b/hash-set-tests.asd
@@ -3,8 +3,11 @@
 (defsystem #:hash-set-tests
   :serial t
   :description "An implementation of the hash-set data structure."
-  :author "Samuel Chase <samebchase@gmail.com>"
+  :author '("Samuel Chase <samebchase@gmail.com>"
+            "Jeremiah LaRocco <jeremiah_larocco@fastmail.com"
+            )
   :license "Unlicense"
   :depends-on (#:hash-set
                #:fiveam)
-  :components ((:file "test")))
+  :components ((:file "test")
+               (:file "benchmark")))

--- a/hash-set.asd
+++ b/hash-set.asd
@@ -3,7 +3,8 @@
 (defsystem #:hash-set
   :serial t
   :description "An implementation of the hash-set data structure."
-  :author "Samuel Chase <samebchase@gmail.com>"
+  :author '("Samuel Chase <samebchase@gmail.com>"
+            "Jeremiah LaRocco <jeremiah_larocco@fastmail.com")
   :license "Unlicense"
   :depends-on (#:alexandria)
   :components ((:file "package")

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -86,13 +86,13 @@
   (= 0 (hs-count hash-set)))
 
 (defun hs-equal (hs-a hs-b)
-  (if (/= (hs-count hs-a) (hs-count hs-b))
-      nil
-      (progn
-        (dohashset (elt hs-a)
-          (unless (hs-memberp hs-b elt)
-            (return nil)))
-        t)))
+  (when (/= (hs-count hs-a) (hs-count hs-b))
+    (return-from hs-equal nil))
+
+  (dohashset (elt hs-a)
+    (when (not (hs-memberp hs-b elt))
+      (return nil)))
+  t)
 
 (defun hs-copy (hash-set)
   (let ((hs-copy (make-hash-set (hs-count hash-set))))

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -1,22 +1,27 @@
 (in-package :hash-set)
 
+(declaim (inline hs-map hs-copy ))
+(defun make-hs-hash-table (size-hint)
+  #+sbcl(make-hash-table :test #'equal :synchronized t :size size-hint)
+  #+clozure(make-hash-table :test #'equal :shared t :size size-hint)
+  #-(or sbcl clozure)(make-hash-table :test #'equal :size size-hint)
+  )
+
+
+
 (defclass hash-set ()
   (
-   #+sbcl (table :accessor table
-                 :initform (make-hash-table :test #'equal :synchronized t)
-                 :initarg :table)
-   #+clozure (table :accessor table :initform (make-hash-table :test #'equal :shared t))
-   #-(or sbcl clozure) (table :accessor table :initform (make-hash-table :test #'equal))
+   (table :accessor table
+          :initform (make-hs-hash-table 10)
+          :initarg :table)
    )
   (:documentation "A hashset."))
 
-(declaim (inline hs-map hs-copy))
+
 (defun make-hash-set (&optional size-hint)
-  (make-instance 'hash-set :table (make-hash-table :test #'equal
-                                                   :synchronized t
-                                                   :size (if size-hint
-                                                             size-hint
-                                                             10))))
+  (make-instance 'hash-set :table (make-hs-hash-table (if size-hint
+                                                          size-hint
+                                                          10))))
 
 (defun hs-map (fn hash-set)
   (let ((result (make-hash-set)))

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -151,9 +151,17 @@
   hs-a)
 
 (defun hs-intersection (hs-a hs-b)
-  (let ((result (make-hash-set)))
-    (dohashset (elt hs-a)
-      (when (hs-memberp hs-b elt)
+  (let ((result (make-hash-set))
+        ;; Loop over the smaller of the sets
+        ;; and check if the entries exists in the larger
+        (smaller (if (< (hs-count hs-a) (hs-count hs-b))
+                     hs-a
+                     hs-b))
+        (larger (if (< (hs-count hs-a) (hs-count hs-b))
+                hs-b
+                hs-a)))
+    (dohashset (elt smaller)
+      (when (hs-memberp larger elt)
         (hs-ninsert result elt)))
     result))
 

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -2,14 +2,21 @@
 
 (defclass hash-set ()
   (
-   #+sbcl (table :accessor table :initform (make-hash-table :test #'equal :synchronized t))
+   #+sbcl (table :accessor table
+                 :initform (make-hash-table :test #'equal :synchronized t)
+                 :initarg :table)
    #+clozure (table :accessor table :initform (make-hash-table :test #'equal :shared t))
    #-(or sbcl clozure) (table :accessor table :initform (make-hash-table :test #'equal))
    )
   (:documentation "A hashset."))
 
-(defun make-hash-set ()
-  (make-instance 'hash-set))
+(declaim (inline hs-map hs-copy))
+(defun make-hash-set (&optional size-hint)
+  (make-instance 'hash-set :table (make-hash-table :test #'equal
+                                                   :synchronized t
+                                                   :size (if size-hint
+                                                             size-hint
+                                                             10))))
 
 (defun hs-map (fn hash-set)
   (let ((result (make-hash-set)))
@@ -75,7 +82,7 @@
         t)))
 
 (defun hs-copy (hash-set)
-  (let ((hs-copy (make-hash-set)))
+  (let ((hs-copy (make-hash-set (hs-count hash-set))))
     (dohashset (elt hash-set)
       (hs-ninsert hs-copy elt))
     hs-copy))

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -187,10 +187,16 @@
   hs-a)
 
 (defun hs-difference (hs-a hs-b)
-  (let ((result (hs-copy hs-a)))
-    (dohashset (elt hs-b)
-      (hs-nremove result elt))
-    result))
+  (let ((smaller (if (< (hs-count hs-a) (hs-count hs-b))
+                     hs-a
+                     hs-b))
+        (larger (if (< (hs-count hs-a) (hs-count hs-b))
+                    hs-b
+                    hs-a)))
+    (let ((result (hs-copy larger)))
+      (dohashset (elt smaller)
+        (hs-nremove result elt))
+      result)))
 
 (defun hs-ndifference (hs-a hs-b)
   (dohashset (elt hs-b)

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -30,16 +30,17 @@
 
 (defun hs-map (fn hash-set)
   (let ((result (make-hash-set)))
-    (loop for key being the hash-keys of (table hash-set)
-       do (hs-ninsert result (funcall fn key)))
+    (loop
+      :for key :being :the :hash-keys :of (table hash-set)
+      :do (hs-ninsert result (funcall fn key)))
     result))
 
 (defmacro dohashset ((var hash-set &optional result) &body body)
-  ;; magic due to pjb from #lisp
-  `(block nil (hs-map (lambda (,var)
-                        (tagbody ,@body))
-                      ,hash-set)
-          ,result))
+  `(loop
+     :for ,var :being :the :hash-keys :of (table ,hash-set)
+     :do
+        (tagbody ,@body)
+     :finally (return ,result)))
 
 (defun hs (&rest values)
   (list-to-hs values))

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -1,6 +1,11 @@
 (in-package :hash-set)
 
-(declaim (inline hs-map hs-copy ))
+(declaim (inline hs-map
+                 hs-copy
+                 hs-memberp
+                 hs-count
+                 hs-ninsert
+                 hs-insert))
 (defun make-hs-hash-table (size-hint)
   #+sbcl(make-hash-table :test #'equal :synchronized t :size size-hint)
   #+clozure(make-hash-table :test #'equal :shared t :size size-hint)

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -263,7 +263,7 @@
   (hs-proper-subsetp hs-subset hs-superset))
 
 (defun hs-any (predicate hash-set)
-  "Test if any elements of `hash-set` satisfy `predicate` and returns `t` and the element.  Returns `nil` if no elements satisfy `predicate`"
+  "Test if any elements of `hash-set` satisfy `predicate` and returns `t` and the first element found.  Returns `nil` if no elements satisfy `predicate`"
   (declare (type hash-set hash-set)
            (type function predicate))
   (dohashset (elt hash-set nil)

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -116,7 +116,7 @@
     (return-from hs-equal nil))
   (dohashset (elt hs-a t)
     (when (not (hs-memberp hs-b elt))
-      (return nil))))
+      (return-from hs-equal nil))))
 
 (defun hs-copy (hash-set &optional (extra-capacity 0))
   "Return a copy of `hash-set`, with `extra-capacity` extra capacity pre-allocated."

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -15,18 +15,15 @@
 
 
 (defclass hash-set ()
-  (
-   (table :accessor table
+  ((table :accessor table
           :initform (make-hs-hash-table 10)
-          :initarg :table)
-   )
+          :initarg :table))
   (:documentation "A hashset."))
 
 
-(defun make-hash-set (&optional size-hint)
-  (make-instance 'hash-set :table (make-hs-hash-table (if size-hint
-                                                          size-hint
-                                                          10))))
+(defun make-hash-set (&optional (size-hint 10))
+  (declare (type integer size-hint))
+  (make-instance 'hash-set :table (make-hs-hash-table size-hint)))
 
 (defun hs-map (fn hash-set)
   (let ((result (make-hash-set (hs-count hash-set))))
@@ -84,15 +81,19 @@
     result))
 
 (defun hs-count (hash-set)
+  (declare (type hash-set hash-set))
   (hash-table-count (table hash-set)))
 
 (defun hs-emptyp (hash-set)
+  (declare (type hash-set hash-set))
   (= 0 (hs-count hash-set)))
 
 (defun hs-memberp (hash-set item)
+  (declare (type hash-set hash-set))
   (nth-value 1 (gethash item (table hash-set))))
 
 (defun hs-equal (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (when (/= (hs-count hs-a) (hs-count hs-b))
     (return-from hs-equal nil))
   (dohashset (elt hs-a t)
@@ -100,11 +101,14 @@
       (return nil))))
 
 (defun hs-copy (hash-set &optional (extra-capacity 0))
+  (declare (type hash-set hash-set)
+           (type fixnum extra-capacity))
   (let ((hs-copy (make-hash-set (+ extra-capacity (hs-count hash-set)))))
     (dohashset (elt hash-set hs-copy)
       (hs-ninsert hs-copy elt))))
 
 (defun hs-filter (fn hash-set)
+  (declare (type hash-set hash-set))
   (let ((result (make-hash-set (floor (* 0.5 (hs-count hash-set))))))
     (dohashset (elt hash-set result)
       (when (funcall fn elt)
@@ -113,113 +117,141 @@
 
 
 (defun hs-insert (hash-set item)
+  (declare (type hash-set hash-set))
   (let ((result (hs-copy hash-set 1)))
     (setf (gethash item (table result)) t)
     result))
 
 (defun hs-ninsert (hash-set item)
+  (declare (type hash-set hash-set))
   (setf (gethash item (table hash-set)) t)
   hash-set)
 
 (defun hs-remove (hash-set item)
+  (declare (type hash-set hash-set))
   (let ((result (hs-copy hash-set)))
     (when (hs-memberp result item)
       (remhash item (table result)))
     result))
 
 (defun hs-nremove (hash-set item)
+  (declare (type hash-set hash-set))
   (remhash item (table hash-set))
   hash-set)
 
 (defun hs-remove-if (predicate hash-set)
+  (declare (type hash-set hash-set)
+           (type function predicate))
   (let ((result (hs-copy hash-set)))
     (dohashset (elt result result)
       (when (funcall predicate elt)
         (hs-nremove result elt)))))
 
 (defun hs-nremove-if (predicate hash-set)
+  (declare (type hash-set hash-set)
+           (type function predicate))
   (dohashset (elt hash-set hash-set)
     (when (funcall predicate elt)
       (hs-nremove hash-set elt))))
 
 (defun hs-remove-if-not (predicate hash-set)
+  (declare (type hash-set hash-set)
+           (type function predicate))
   (let ((result (hs-copy hash-set)))
     (dohashset (elt result result)
       (unless (funcall predicate elt)
         (hs-nremove result elt)))))
 
 (defun hs-nremove-if-not (predicate hash-set)
+  (declare (type hash-set hash-set)
+           (type function predicate))
   (dohashset (elt hash-set hash-set)
     (unless (funcall predicate elt)
       (hs-nremove hash-set elt))))
 
 (defun hs-union (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (let ((result (hs-copy hs-a (hs-count hs-b))))
     (dohashset (elt hs-b result)
       (hs-ninsert result elt))))
 
 (defun hs-nunion (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (dohashset (elt hs-b hs-a)
     (hs-ninsert hs-a elt)))
 
 (defun hs-intersection (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (let* (
-        ;; Loop over the smaller of the sets
-        ;; and check if the entries exists in the larger
-        (smaller (if (< (hs-count hs-a) (hs-count hs-b))
-                     hs-a
-                     hs-b))
-        (larger (if (< (hs-count hs-a) (hs-count hs-b))
-                hs-b
-                hs-a))
-        (result (make-hash-set (hs-count smaller))))
+         ;; Loop over the smaller of the sets
+         ;; and check if the entries exists in the larger
+         (smaller (if (< (hs-count hs-a) (hs-count hs-b))
+                      hs-a
+                      hs-b))
+         (larger (if (< (hs-count hs-a) (hs-count hs-b))
+                     hs-b
+                     hs-a))
+         (result (make-hash-set (hs-count smaller))))
     (dohashset (elt smaller result)
       (when (hs-memberp larger elt)
         (hs-ninsert result elt)))))
 
 (defun hs-nintersection (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (dohashset (elt hs-a hs-a)
     (unless (hs-memberp hs-b elt)
       (hs-nremove hs-a elt))))
 
 (defun hs-difference (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (let ((result (hs-copy hs-a)))
     (dohashset (elt hs-b result)
       (hs-nremove result elt))))
 
 (defun hs-ndifference (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (dohashset (elt hs-b hs-a)
     (hs-nremove hs-a elt)))
 
 (defun hs-symmetric-difference (hs-a hs-b)
+  (declare (type hash-set hs-a hs-b))
   (hs-union (hs-difference hs-a hs-b)
             (hs-difference hs-b hs-a)))
 
 (defun hs-subsetp (hs-subset hs-superset)
+  (declare (type hash-set hs-subset hs-superset))
   (dohashset (subset-elt hs-subset t)
     (unless (hs-memberp hs-superset subset-elt)
       (return-from hs-subsetp nil))))
 
 (defun hs-proper-subsetp (hs-subset hs-superset)
+  (declare (type hash-set hs-subset hs-superset))
   (and (hs-subsetp hs-subset hs-superset)
        (> (hs-count hs-superset) (hs-count hs-subset))))
 
 (defun hs-supersetp (hs-superset hs-subset)
+  (declare (type hash-set hs-subset hs-superset))
   (hs-subsetp hs-subset hs-superset))
 
 (defun hs-proper-supersetp (hs-superset hs-subset)
+  (declare (type hash-set hs-subset hs-superset))
   (hs-proper-subsetp hs-subset hs-superset))
 
 (defun hs-any (predicate hash-set)
+  (declare (type hash-set hash-set)
+           (type function predicate))
   (dohashset (elt hash-set nil)
     (when (funcall predicate elt)
       (return-from hs-any t))))
 
 (defun hs-all (predicate hash-set)
+  (declare (type hash-set hash-set)
+           (type function predicate))
   (dohashset (elt hash-set t)
     (unless (funcall predicate elt)
       (return-from hs-all nil))))
 
+(declaim (inline %one-bit-positions))
 (defun %one-bit-positions (n)
   (loop
     :with result = (make-hash-set 64)
@@ -230,10 +262,14 @@
     :finally (return result)))
 
 (defun hs-powerset (hash-set)
+  (declare (type hash-set hash-set)
+           (optimize (speed 3) (space 3)))
   (let* ((result-length (expt 2 (hs-count hash-set)))
          (result (make-hash-set result-length))
          (indexed-set-table (make-hash-table :test 'equal))
          (idx 0))
+    (declare (type fixnum idx result-length)
+             (type hash-set result))
     (flet ((subset-from-bit-repr-int (bit-repr-int)
              (let ((result (make-hash-set 64)))
                (dohashset (var (%one-bit-positions bit-repr-int) result)
@@ -242,12 +278,19 @@
         (setf (gethash idx indexed-set-table) var)
         (incf idx))
       (loop
-        :for bit-repr :from 0 :below result-length
-         :do (hs-ninsert result (subset-from-bit-repr-int bit-repr))))
+        :for bit-repr fixnum :from 0 :below result-length
+        :do (hs-ninsert result (subset-from-bit-repr-int bit-repr))))
     result))
 
 (defun hs-cartesian-product (hs-a hs-b)
-  (let ((result (make-hash-set (* (hs-count hs-a) (hs-count hs-b)))))
+  (declare (type hash-set hs-a hs-b)
+           (optimize (speed 3) (space 3)))
+  (let* ((a-cnt (the fixnum (hs-count hs-a)))
+         (b-cnt (the fixnum (hs-count hs-b)))
+         (mul (the fixnum (* a-cnt b-cnt)))
+         (result (make-hash-set (the fixnum mul))))
+    (declare (type fixnum a-cnt b-cnt mul)
+             (type hash-set result))
     (dohashset (elt-a hs-a result)
       (dohashset (elt-b hs-b)
         (hs-ninsert result (list elt-a elt-b))))))
@@ -257,19 +300,25 @@
     (format stream "of count: ~a" (hs-count hash-set))))
 
 (declaim (inline hs-first))
-(defun hs-first (hs)
+(defun hs-first (hash-set)
+(declare (type hash-set hash-set)
+           (optimize (speed 3) (space 3)))
   (loop :for i :below 1
-        :for key :being :the :hash-keys :of (table hs)
+        :for key :being :the :hash-keys :of (table hash-set)
         :finally (return key)))
 
-(defun hs-pop (hs)
-  (let* ((element (hs-first hs))
-         (result (hs-remove hs element)))
+(defun hs-pop (hash-set)
+  (declare (type hash-set hash-set)
+           (optimize (speed 3) (space 3)))
+  (let* ((element (hs-first hash-set))
+         (result (hs-remove hash-set element)))
     (values element result)))
 
-(defun hs-npop (hs)
-  (let ((element (hs-first hs)))
-    (hs-nremove hs element)
-    (values element hs)))
+(defun hs-npop (hash-set)
+  (declare (type hash-set hash-set)
+           (optimize (speed 3) (space 3)))
+  (let ((element (hs-first hash-set)))
+    (hs-nremove hash-set element)
+    (values element hash-set)))
 
 

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -36,12 +36,15 @@
                       ,hash-set)
           ,result))
 
+(defun hs (&rest values)
+  (list-to-hs values))
+
 (defun list-to-hs (list)
   (let ((hash-set (make-hash-set)))
     (loop for elt in list do
-         (if (consp elt)
-             (hs-ninsert hash-set (list-to-hs elt))
-             (hs-ninsert hash-set elt)))
+      (if (consp elt)
+          (hs-ninsert hash-set (list-to-hs elt))
+          (hs-ninsert hash-set elt)))
     hash-set))
 
 (defun hs-to-list (hash-set)
@@ -267,3 +270,20 @@
 (defmethod print-object ((hash-set hash-set) stream)
   (print-unreadable-object (hash-set stream :identity t :type t)
     (format stream "of count: ~a" (hs-count hash-set))))
+
+(declaim (inline hs-first))
+(defun hs-first (hs)
+  (loop :for i :below 1
+        :for key :being :the :hash-keys :of (table hs)
+        :finally (return key)))
+(defun hs-pop (hs)
+  (let* ((element (hs-first hs))
+         (result (hs-remove hs element)))
+    (values element result)))
+
+(defun hs-npop (hs)
+  (let ((element (hs-first hs)))
+    (hs-nremove hs element)
+    (values element hs)))
+
+

--- a/hash-set.lisp
+++ b/hash-set.lisp
@@ -192,16 +192,10 @@
   hs-a)
 
 (defun hs-difference (hs-a hs-b)
-  (let ((smaller (if (< (hs-count hs-a) (hs-count hs-b))
-                     hs-a
-                     hs-b))
-        (larger (if (< (hs-count hs-a) (hs-count hs-b))
-                    hs-b
-                    hs-a)))
-    (let ((result (hs-copy larger)))
-      (dohashset (elt smaller)
-        (hs-nremove result elt))
-      result)))
+  (let ((result (hs-copy hs-a)))
+    (dohashset (elt hs-b)
+      (hs-nremove result elt))
+    result))
 
 (defun hs-ndifference (hs-a hs-b)
   (dohashset (elt hs-b)

--- a/package.lisp
+++ b/package.lisp
@@ -3,6 +3,7 @@
 (defpackage #:hash-set
   (:use #:cl)
   (:export #:hash-set
+           #:hs
            #:make-hash-set
            #:list-to-hs
            #:hs-to-list
@@ -32,6 +33,10 @@
            #:hs-map
            #:hs-filter
            #:dohashset
+
+           #:hs-first
+           #:hs-pop
+           #:hs-npop
 
            #:hs-count
 

--- a/test.lisp
+++ b/test.lisp
@@ -123,7 +123,7 @@
 (test hs-union
   (is (hs-equal (hs-union (list-to-hs ())
                           (list-to-hs ()))
-                (list-to-hs ())))                
+                (list-to-hs ())))
   (is (hs-equal (hs-union (list-to-hs '(0 1 2 3))
                           (list-to-hs '(4 5 6 7)))
                 (list-to-hs (alexandria:iota 8)))))
@@ -212,9 +212,14 @@
                                  (list-to-hs '(4 5 6 7)))))
 
 (test hs-powerset
-  (is (hs-equal (hs-powerset (list-to-hs '(1 2 3)))
+  ;; This is clunky but equal comparison fails on hash-sets...
+  ;; Really we need the underlying hash-table to use hs-equal.
+  ;; But for now, break out the inner sets to lists that work with equal comparison
+  (is (hs-equal (list-to-hs (mapcar #'hs-to-list
+                                    (hs-to-list
+                                     (hs-powerset (hs 1 2 3)))))
                 (list-to-hs '(NIL (1) (2) (1 2) (3) (1 3) (2 3) (1 2 3)))))
-  (is (hs-equal (hs-powerset (list-to-hs '()))
+  (is (hs-equal (list-to-hs (mapcar #'hs-to-list (hs-to-list (hs-powerset (hs)))))
                 (list-to-hs '(())))))
 
 (test hs-pop
@@ -233,7 +238,7 @@
         :do (setf (values popped-value new-set) (hs-pop current-set))
             (check-pop current-set new-set popped-value))
       (is (= original-size (hs-count original))))
-    
+
     (let ((original (hs 1 2 3 4 5)))
       (loop
         :with current-set = original
@@ -249,7 +254,7 @@
 
     (loop :for key :in keys
           :for value :in values
-          :do (push value (gethash key hash-table))
+          :do (setf (gethash key hash-table) value)
               (hs-ninsert tuple-set (cons key value)))
 
     (is (hs-equal (list-to-hs keys)

--- a/test.lisp
+++ b/test.lisp
@@ -84,7 +84,7 @@
 
 (test hs-nremove-if-not
   (let ((hash-set (list-to-hs (alexandria:iota 10))))
-    (hs-nremove-if #'oddp hash-set)
+    (hs-nremove-if-not #'oddp hash-set)
     (is (hs-equal hash-set
                   (list-to-hs (alexandria:iota 5 :start 1 :step 2))))))
 

--- a/test.lisp
+++ b/test.lisp
@@ -217,6 +217,30 @@
   (is (hs-equal (hs-powerset (list-to-hs '()))
                 (list-to-hs '(())))))
 
+(test hs-pop
+  (flet ((check-pop (old-set new-set value)
+           (is (hs-memberp old-set value))
+           (is (not (hs-memberp new-set value)))
+           (is (= 1
+                  (- (hs-count old-set)
+                     (hs-count new-set))))))
+    (let* ((original (hs 1 2 3 4 5))
+           (original-size (hs-count original)))
+      (loop
+        :with popped-value :and new-set
+        :for current-set = original :then new-set
+        :until (zerop (hs-count current-set))
+        :do (setf (values popped-value new-set) (hs-pop current-set))
+            (check-pop current-set new-set popped-value))
+      (is (= original-size (hs-count original))))
+    
+    (let ((original (hs 1 2 3 4 5)))
+      (loop
+        :with current-set = original
+        :until (zerop (hs-count current-set))
+        :do (hs-npop current-set))
+      (is (zerop (hs-count original))))))
+
 (test hash-table-hash-set-conversions
   (let ((hash-table (make-hash-table))
         (keys '(:one :two :three :four))
@@ -224,9 +248,9 @@
         (tuple-set (make-hash-set)))
 
     (loop :for key :in keys
-       :for value :in values
-       :do (push value (gethash key hash-table))
-       (hs-ninsert tuple-set (cons key value)))
+          :for value :in values
+          :do (push value (gethash key hash-table))
+              (hs-ninsert tuple-set (cons key value)))
 
     (is (hs-equal (list-to-hs keys)
                   (hash-keys-to-set hash-table)))

--- a/test.lisp
+++ b/test.lisp
@@ -215,10 +215,10 @@
   ;; This is clunky but equal comparison fails on hash-sets...
   ;; Really we need the underlying hash-table to use hs-equal.
   ;; But for now, break out the inner sets to lists that work with equal comparison
-  (is (hs-equal (list-to-hs (mapcar #'hs-to-list
-                                    (hs-to-list
-                                     (hs-powerset (hs 1 2 3)))))
+  (is (hs-equal (list-to-hs (sort  (mapcar (lambda (lst) (sort lst #'<))(mapcar #'hs-to-list (hs-to-list (hs-powerset (hs 1 2 3))))) #'< :key #'length))
                 (list-to-hs '(NIL (1) (2) (1 2) (3) (1 3) (2 3) (1 2 3)))))
+
+
   (is (hs-equal (list-to-hs (mapcar #'hs-to-list (hs-to-list (hs-powerset (hs)))))
                 (list-to-hs '(())))))
 


### PR DESCRIPTION
I'm not sure how to handle this PR.  There are quite a few independent changes in the branch, and I'd be happy to split it up into multiple PRs.  Or skip some changes entirely if they don't align with the project goals.  Just let me know.

In any case, I needed a simple set data structure for something, and started writing my own when I realized it must exist already and found this project.

My branch started off as a quick optimization of hs-intersection (to iterate over the smaller of hs-a or hs-b) and kind of grew from there into some more optimizations and some bug fixes.  I added `hs-first`, `hs-pop`, and `hs-npop` because I needed them for my application.

* Removed call to `hs-map` in `dohashset` - this avoids the `result` hash-set that `hs-map` creates
* Added `size-hint` to `make-hash-set` and `hs-copy` - this reduces memory allocation quite a bit in many cases, especially for `hs-copy` of large sets.
* Fixed `hs-equal`
* Fixed broken tests masked by broken `hs-equal`
* Added type declarations and a few optimize declarations to several functions.
* Added ftype declarations from many functions
* Added documentation strings to many functions and types.
* Added some very simple benchmarks to the test suite (using time :-()
* Made several non-mutating functions use their mutating counterparts - e.g. `hs-union` now calls `(hs-nunion (hs-copy hs-a) hs-b)`
* Use the `result` parameter to `dohashset` in more places.
* Added `hs` - a  `&rest` argument short-hand for `list-to-hs`
* `hs-to-list` and `list-to-hs` no longer recursively convert nested sets and lists.  I wasn't expecting that behavior, and there are issues using hash-sets as keys (for example `(hs-equal (hs (hs 1) (hs 2) (hs 3)) (hs (hs 1) (hs 2) (hs 3)))` -> `nil`, where as `(hs-equal (hs '(1) '(2) '(3)) (hs '(1) '(2) '(3)))` -> `t`)
* Fixed the `hs-powerset` unit test which was failing due to the previous issue
* Added `hs-pop`, `hs-npop`, and `hs-first` to query the "first" element, and modifying/non-modifying versions of a function to return and remove the element.


I know there's a lot there, but the changes generally make the `hash-set` work better and quite a bit faster in some cases.